### PR TITLE
Stop enemy spawning when altar is destroyed

### DIFF
--- a/Shared/Component/PortalSpawnEnemyComponent.swift
+++ b/Shared/Component/PortalSpawnEnemyComponent.swift
@@ -31,11 +31,10 @@ class PortalSpawnEnemyComponent: Component {
 
     private func spawnEnemy() {
         guard let map = entity?.map else { return }
+        guard let altar = map.entities.compactMap({ $0 as? Altar }).first else { return }
         let enemy = enemyFactory()
         enemy.moveComponent?.position = entity?.node.position ?? .zero
-        if let altar = map.entities.compactMap({ $0 as? Altar }).first {
-            enemy.moveComponent?.target = altar.node.position
-        }
+        enemy.moveComponent?.target = altar.node.position
         map.addEntity(enemy)
     }
 }


### PR DESCRIPTION
## Summary
- Add guard check in PortalSpawnEnemyComponent to prevent spawning when altar doesn't exist
- Fixes issue where enemies continue spawning after altar is destroyed
- Spawning automatically resumes when an altar becomes available again

## Test plan
- [ ] Run game and destroy the altar
- [ ] Verify that enemy spawning stops when altar health reaches 0
- [ ] Verify that spawning resumes if altar is placed again

🤖 Generated with [Claude Code](https://claude.ai/code)