### PR TITLE
Add bottom icon button row UI component

### DIFF
--- a/Shared/GameScene.swift
+++ b/Shared/GameScene.swift
@@ -17,6 +17,7 @@ class GameScene: SKScene {
     private var pinchAnchorScene: CGPoint = .zero
     private var pinchAnchorLocal: CGPoint = .zero
     private var goldLabel: SKLabelNode!
+    private var iconButtonRow: IconButtonRow!
 
     override init(size: CGSize) {
         super.init(size: size)
@@ -43,6 +44,9 @@ class GameScene: SKScene {
         
         // Setup gold display UI
         setupGoldDisplay()
+        
+        // Setup icon buttons UI
+        setupIconButtonRow()
     }
 }
 
@@ -175,6 +179,16 @@ private extension GameScene {
     }
 }
 
+// MARK: - Icon Buttons
+private extension GameScene {
+    func setupIconButtonRow() {
+        iconButtonRow = IconButtonRow()
+        iconButtonRow.position = CGPoint(x: size.width / 2, y: 60)
+        iconButtonRow.zPosition = 1000
+        addChild(iconButtonRow)
+    }
+}
+
 // MARK: - Update
 extension GameScene {
     override func update(_ currentTime: TimeInterval) {
@@ -192,6 +206,7 @@ extension GameScene {
         super.didChangeSize(oldSize)
         updateZoomLimits()
         goldLabel?.position = CGPoint(x: size.width - 20, y: size.height - 20)
+        iconButtonRow?.position = CGPoint(x: size.width / 2, y: 60)
     }
 }
 

--- a/Shared/Node/IconButtonRow.swift
+++ b/Shared/Node/IconButtonRow.swift
@@ -1,0 +1,39 @@
+//
+//  IconButtonRow.swift
+//  RushDefense Shared
+//
+//  Icon button row UI component for bottom center of game scene.
+//
+
+import SpriteKit
+
+class IconButtonRow: SKNode {
+    
+    override init() {
+        super.init()
+        setupButtons()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupButtons() {
+        let buttonSize: CGFloat = 40
+        let spacing: CGFloat = 10
+        let totalButtons = 9
+        let totalWidth = CGFloat(totalButtons) * buttonSize + CGFloat(totalButtons - 1) * spacing
+        let startX = -totalWidth / 2
+        
+        for i in 1...totalButtons {
+            let button = SKSpriteNode(imageNamed: "Icon_0\(i)")
+            button.size = CGSize(width: buttonSize, height: buttonSize)
+            button.position = CGPoint(
+                x: startX + CGFloat(i - 1) * (buttonSize + spacing) + buttonSize / 2,
+                y: 0
+            )
+            button.name = "iconButton_\(i)"
+            addChild(button)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a row of 9 icon buttons at the bottom center of the game scene for future UI interactions.

## Changes
- **New IconButtonRow class**: Modular SKNode subclass for icon button management
- **Bottom center positioning**: Icons displayed at screen bottom with responsive layout  
- **Asset integration**: Uses existing Icon_01 through Icon_09 assets
- **Clean architecture**: Encapsulated UI logic separate from GameScene

## Implementation Details
- 40px buttons with 10px spacing, centered horizontally
- Positioned 60px from bottom edge
- High z-position (1000) to appear above game elements
- Named buttons (`iconButton_1` to `iconButton_9`) ready for touch handling
- Responsive positioning that adapts to scene size changes

## Test Plan
- [x] Icons display correctly in game scene
- [x] Proper spacing and alignment at bottom center
- [x] Responsive layout on scene size changes
- [ ] Ready for future touch interaction implementation

🤖 Generated with [Claude Code](https://claude.ai/code)