### PR TITLE
Split AttackComponent into MeleeAttackComponent and ProjectileAttackComponent

### DIFF
--- a/Shared/Component/AttackComponent.swift
+++ b/Shared/Component/AttackComponent.swift
@@ -17,18 +17,16 @@ class AttackComponent: Component {
     var targetEntityType: EntityType = [.enemy]
     var target: Entity?
     var knockback: CGFloat = 20 // interpreted as impulse magnitude
-    var projectileSpeed: CGFloat = 400
-    var projectileMaxDistance: CGFloat = 1000
 
     override func update(deltaTime seconds: TimeInterval) {
         super.update(deltaTime: seconds)
         if lastUpdateTime - lastTryAttackTime >= attackInterval {
             lastTryAttackTime = lastUpdateTime
-            performAttack()
+            tryAttack()
         }
     }
 
-    func performAttack() {
+    func tryAttack() {
         guard let entity = entity else { return }
 
         if let target,
@@ -59,20 +57,12 @@ class AttackComponent: Component {
         }
 
         if let target {
-            // Fire a simple projectile toward the current target.
-            let origin = entity.node.position
-            let targetPos = target.node.position
-            let toTarget = targetPos - origin
-            let dir = toTarget.length > 0 ? toTarget / toTarget.length : CGPoint(x: 1, y: 0)
-            let projectile = Projectile(speed: projectileSpeed,
-                                        maxDistance: projectileMaxDistance,
-                                        damage: attackDamage,
-                                        knockback: knockback,
-                                        direction: dir,
-                                        ownerType: entity.entityType)
-            projectile.moveComponent?.position = origin
-            entity.map?.addEntity(projectile)
-            lastAttackTime = lastTryAttackTime
+            performAttack(on: target)
         }
+    }
+    
+    // Subclasses should override this method to implement their specific attack behavior
+    func performAttack(on target: Entity) {
+        // Base implementation does nothing - subclasses should override
     }
 }

--- a/Shared/Component/MeleeAttackComponent.swift
+++ b/Shared/Component/MeleeAttackComponent.swift
@@ -1,0 +1,34 @@
+//
+//  MeleeAttackComponent.swift
+//  RushDefense
+//
+//  Created by Luke Zhao on 9/13/25.
+//
+
+import Foundation
+
+class MeleeAttackComponent: AttackComponent {
+    
+    override init() {
+        super.init()
+        attackRange = 50
+    }
+
+    override func performAttack(on target: Entity) {
+        guard let entity = entity else { return }
+        
+        // Direct melee attack - apply damage and knockback immediately
+        target.healthComponent?.takeDamage(attackDamage)
+        
+        // Apply knockback using the same method as ProjectileComponent
+        if let targetMoveComponent = target.moveComponent {
+            let origin = entity.node.position
+            let targetPos = target.node.position
+            let toTarget = targetPos - origin
+            let dir = toTarget.length > 0 ? toTarget / toTarget.length : CGPoint(x: 1, y: 0)
+            targetMoveComponent.applyImpulse(dir * knockback)
+        }
+        
+        lastAttackTime = lastTryAttackTime
+    }
+}

--- a/Shared/Component/ProjectileAttackComponent.swift
+++ b/Shared/Component/ProjectileAttackComponent.swift
@@ -1,0 +1,37 @@
+//
+//  ProjectileAttackComponent.swift
+//  RushDefense
+//
+//  Created by Luke Zhao on 9/13/25.
+//
+
+import Foundation
+
+class ProjectileAttackComponent: AttackComponent {
+    var projectileSpeed: CGFloat = 400
+    var projectileMaxDistance: CGFloat = 1000
+
+    override init() {
+        super.init()
+        attackRange = 150
+    }
+
+    override func performAttack(on target: Entity) {
+        guard let entity = entity else { return }
+        
+        // Fire a simple projectile toward the current target.
+        let origin = entity.node.position
+        let targetPos = target.node.position
+        let toTarget = targetPos - origin
+        let dir = toTarget.length > 0 ? toTarget / toTarget.length : CGPoint(x: 1, y: 0)
+        let projectile = Projectile(speed: projectileSpeed,
+                                    maxDistance: projectileMaxDistance,
+                                    damage: attackDamage,
+                                    knockback: knockback,
+                                    direction: dir,
+                                    ownerType: entity.entityType)
+        projectile.moveComponent?.position = origin
+        entity.map?.addEntity(projectile)
+        lastAttackTime = lastTryAttackTime
+    }
+}

--- a/Shared/Entity/Building/Turret.swift
+++ b/Shared/Entity/Building/Turret.swift
@@ -17,7 +17,7 @@ class Turret: Entity {
         collisionRadius = 20
         addComponent(HealthComponent(maxHealth: 200))
         addComponent(TurretVisualComponent(turretType: turretType))
-        addComponent(AttackComponent().then({ component in
+        addComponent(ProjectileAttackComponent().then({ component in
             component.attackRange = 120
             component.attackDamage = 30
             component.attackInterval = 0.8

--- a/Shared/Entity/Enemy/Bear.swift
+++ b/Shared/Entity/Enemy/Bear.swift
@@ -22,7 +22,7 @@ class Bear: Entity {
         addComponent(HealthComponent(maxHealth: 100))
         addComponent(IdleAttackRunVisualComponent(texturePrefix: "Enemies/Bear"))
         // Enemy can attack ally buildings at short range
-        addComponent(AttackComponent().then({ component in
+        addComponent(MeleeAttackComponent().then({ component in
             component.attackRange = 10
             component.attackDamage = 2
             component.targetEntityType = [.building]


### PR DESCRIPTION
## Summary
- Split AttackComponent into a base class with shared targeting logic and two specialized subclasses
- Created MeleeAttackComponent for direct damage/knockback attacks (used by Bear)
- Created ProjectileAttackComponent for projectile-based attacks (used by Turret)
- Improved method naming: performAttack → tryAttack, executeAttack → performAttack
- Aligned knockback implementation to use applyImpulse method consistently

## Test plan
- [x] Project builds without errors
- [x] Bear now uses MeleeAttackComponent for close-range attacks
- [x] Turret continues using projectile attacks via ProjectileAttackComponent
- [x] Visual components still work with base AttackComponent reference
- [ ] Verify Bear melee attacks work correctly in game
- [ ] Verify Turret projectile attacks still function properly

🤖 Generated with [Claude Code](https://claude.ai/code)