### PR TITLE
Add PauseWhenAttackingSteeringBehavior

### DIFF
--- a/Shared/Entity/Enemy/Bear.swift
+++ b/Shared/Entity/Enemy/Bear.swift
@@ -12,11 +12,12 @@ class Bear: Entity {
         super.init()
         entityType = [.enemy]
 
-        // Set up movement with RouteSeekBehavior for pathfinding
+        // Set up movement with RouteSeekBehavior for pathfinding, wrapped with pause-when-attacking
         let routeSeek = RouteSeekBehavior()
+        let pauseWhenAttacking = PauseWhenAttackingSteeringBehavior(wrapping: routeSeek)
         addComponent(MoveComponent().then({
             $0.speed = 40
-            $0.behaviors = [routeSeek, AvoidBehavior()]
+            $0.behaviors = [pauseWhenAttacking, AvoidBehavior()]
         }))
 
         addComponent(HealthComponent(maxHealth: 100))


### PR DESCRIPTION
## Summary
- Implements a new `PauseWhenAttackingSteeringBehavior` that pauses entity movement when actively attacking
- Uses a wrapper pattern to compose with existing steering behaviors
- Updated Bear entity to demonstrate the behavior with RouteSeekBehavior

## Changes
- **SteeringBehavior.swift**: Added `PauseWhenAttackingSteeringBehavior` class that returns zero force when the entity has an active attack target
- **Bear.swift**: Wrapped the existing `RouteSeekBehavior` with the new pause behavior

## Behavior
Entities with both `MoveComponent` and `AttackComponent` will now:
1. Stop moving when they have a valid attack target (as determined by AttackComponent)
2. Resume normal pathfinding/movement when no longer attacking
3. Maintain all other steering behaviors (like avoidance)

## Test plan
- [ ] Build the project successfully
- [ ] Run the game and verify bears stop moving when attacking buildings
- [ ] Verify bears resume movement after destroying targets or moving out of range

🤖 Generated with [Claude Code](https://claude.ai/code)