### PR TITLE
Make visual components face targets during attacks

### DIFF
--- a/Shared/Component/Visual/IdleAttackRunVisualComponent.swift
+++ b/Shared/Component/Visual/IdleAttackRunVisualComponent.swift
@@ -49,7 +49,17 @@ class IdleAttackRunVisualComponent: VisualComponent {
         guard let attackComponent = entity?.component(ofType: AttackComponent.self) else { return }
         state = attackComponent.lastAttackTime + 1.0 > lastUpdateTime ? .attack : (moveComponent.isMoving ? .run : .idle)
         let frames = state.textures(for: texturePrefix)
-        sprite.xScale = moveComponent.direction.x < 0 ? -1 : 1
+        
+        // When attacking, face the target. Otherwise, face movement direction.
+        if state == .attack, let target = attackComponent.target {
+            let entityPosition = entity?.node.position ?? .zero
+            let targetPosition = target.node.position
+            let targetDirection = (targetPosition - entityPosition).normalized()
+            sprite.xScale = targetDirection.x < 0 ? -1 : 1
+        } else {
+            sprite.xScale = moveComponent.direction.x < 0 ? -1 : 1
+        }
+        
         if lastUpdateTime > lastTextureUpdateTime + timePerFrame {
             lastTextureUpdateTime = lastUpdateTime
             textureIndex += 1


### PR DESCRIPTION
## Summary
- Modified IdleAttackRunVisualComponent to face attack targets during combat
- When entities are attacking, their sprites now face the target direction
- Falls back to movement-based facing when not attacking
- Improves visual feedback and combat readability

## Changes
- Updated `IdleAttackRunVisualComponent.swift` to calculate target direction during attacks
- Added logic to face target when in attack state, otherwise face movement direction
- Affects all enemies using IdleAttackRunVisualComponent (Spider, Thief, Troll, etc.)

## Test plan
- [x] Build successfully compiles
- [x] Existing tests pass (pre-existing failures unrelated)
- [ ] Manual testing: Verify enemies face their targets when attacking
- [ ] Manual testing: Verify normal movement facing still works when not attacking

🤖 Generated with [Claude Code](https://claude.ai/code)