### PR TITLE
Add random spawn offset to prevent single-line enemy formation

### DIFF
--- a/Shared/Component/PortalSpawnEnemyComponent.swift
+++ b/Shared/Component/PortalSpawnEnemyComponent.swift
@@ -30,7 +30,15 @@ class PortalSpawnEnemyComponent: Component {
         guard let map = entity?.map else { return }
         guard let altar = map.entities.compactMap({ $0 as? Altar }).first else { return }
         let enemy = enemyFactory()
-        enemy.moveComponent?.position = entity?.node.position ?? .zero
+        
+        // Add random offset to prevent enemies from spawning in a single line
+        let basePosition = entity?.node.position ?? .zero
+        let offsetX = Float.random(in: -15...15)
+        let offsetY = Float.random(in: -15...15)
+        let spawnPosition = CGPoint(x: basePosition.x + CGFloat(offsetX), 
+                                   y: basePosition.y + CGFloat(offsetY))
+        
+        enemy.moveComponent?.position = spawnPosition
         
         // Set up pathfinding target for RouteSeekBehavior
         let altarGridLocation = map.grid(for: altar.node.position)

--- a/Shared/Component/WaveSpawnComponent.swift
+++ b/Shared/Component/WaveSpawnComponent.swift
@@ -103,7 +103,15 @@ class WaveSpawnComponent: Component {
         guard let altar = map.entities.compactMap({ $0 as? Altar }).first else { return }
         
         let enemy = EnemyFactory.createEnemy(of: type)
-        enemy.moveComponent?.position = entity?.node.position ?? .zero
+        
+        // Add random offset to prevent enemies from spawning in a single line
+        let basePosition = entity?.node.position ?? .zero
+        let offsetX = Float.random(in: -15...15)
+        let offsetY = Float.random(in: -15...15)
+        let spawnPosition = CGPoint(x: basePosition.x + CGFloat(offsetX), 
+                                   y: basePosition.y + CGFloat(offsetY))
+        
+        enemy.moveComponent?.position = spawnPosition
         
         // Set up pathfinding target for RouteSeekBehavior
         let altarGridLocation = map.grid(for: altar.node.position)


### PR DESCRIPTION
## Summary
- Added random position offsets (±15 points) to enemy spawn locations in both spawn components
- Prevents enemies from spawning in perfectly aligned single rows
- Creates natural visual variation while preserving all pathfinding behavior

## Changes
- **PortalSpawnEnemyComponent.swift**: Added random X/Y offset calculation before setting enemy position
- **WaveSpawnComponent.swift**: Added identical random offset logic to wave-based spawning

## Test plan
- [x] Project builds successfully
- [x] No breaking changes to existing pathfinding or targeting logic
- [ ] Visual verification that enemies spawn with positional variation in-game

🤖 Generated with [Claude Code](https://claude.ai/code)