### PR TITLE
Add projectile and explosion scaling for enemy projectiles

### DIFF
--- a/Shared/Component/ProjectileAttackComponent.swift
+++ b/Shared/Component/ProjectileAttackComponent.swift
@@ -12,6 +12,8 @@ class ProjectileAttackComponent: AttackComponent {
     var projectileMaxDistance: CGFloat = 1000
     var projectileTexture: String = "Projectiles/5"
     var explosionTexture: String = "Effects/4_1"
+    var projectileScale: CGFloat = 1.0
+    var explosionScale: CGFloat = 1.0
 
     override init() {
         super.init()
@@ -33,7 +35,9 @@ class ProjectileAttackComponent: AttackComponent {
                                     direction: dir,
                                     ownerType: entity.entityType,
                                     projectileTexture: projectileTexture,
-                                    explosionTexture: explosionTexture)
+                                    explosionTexture: explosionTexture,
+                                    projectileScale: projectileScale,
+                                    explosionScale: explosionScale)
         projectile.moveComponent?.position = origin
         entity.map?.addEntity(projectile)
         lastAttackTime = lastTryAttackTime

--- a/Shared/Component/ProjectileComponent.swift
+++ b/Shared/Component/ProjectileComponent.swift
@@ -12,6 +12,7 @@ class ProjectileComponent: Component {
     var ownerType: EntityType
     var maxDistance: CGFloat = 1000
     var explosionTexture: String
+    var explosionScale: CGFloat = 1.0
     private var traveled: CGFloat = 0
 
     init(speed: CGFloat, damage: Int, knockback: CGFloat, ownerType: EntityType, explosionTexture: String = "Effects/4_1") {
@@ -33,7 +34,7 @@ class ProjectileComponent: Component {
             let pos = entity.node.position
             let v = entity.moveComponent?.velocity ?? .zero
             let dir = v.length > 0 ? v.normalized() : CGPoint(x: 1, y: 0)
-            let effectNode = EffectNode(position: pos, direction: dir, textureName: explosionTexture, anchorPoint: CGPoint(x: 0.0, y: 0.5))
+            let effectNode = EffectNode(position: pos, direction: dir, textureName: explosionTexture, scale: explosionScale, anchorPoint: CGPoint(x: 0.0, y: 0.5))
             entity.map?.node.addChild(effectNode)
             entity.removeFromMap()
             return
@@ -64,7 +65,7 @@ class ProjectileComponent: Component {
                 other.moveComponent?.applyImpulse(dir * knockback)
 
                 // Impact effect aligned with projectile direction at projectile's hit position
-                let effectNode = EffectNode(position: myPos, direction: dir, textureName: explosionTexture, anchorPoint: CGPoint(x: 0.0, y: 0.5))
+                let effectNode = EffectNode(position: myPos, direction: dir, textureName: explosionTexture, scale: explosionScale, anchorPoint: CGPoint(x: 0.0, y: 0.5))
                 entity.map?.node.addChild(effectNode)
                 entity.removeFromMap()
                 break

--- a/Shared/Entity/Enemy/Gnoll.swift
+++ b/Shared/Entity/Enemy/Gnoll.swift
@@ -31,6 +31,8 @@ class Gnoll: Entity {
             component.projectileMaxDistance = 170
             component.projectileTexture = "Enemies/Gnoll_Bone"
             component.explosionTexture = "Enemies/Gnoll_Hit"
+            component.projectileScale = 0.5
+            component.explosionScale = 0.5
         }))
     }
 }

--- a/Shared/Entity/Enemy/HarpoonFish.swift
+++ b/Shared/Entity/Enemy/HarpoonFish.swift
@@ -30,6 +30,8 @@ class HarpoonFish: Entity {
             component.projectileSpeed = 400 // Fast harpoon
             component.projectileMaxDistance = 220
             component.projectileTexture = "Enemies/Harpoon"
+            component.projectileScale = 0.5
+            component.explosionScale = 0.5
         }))
     }
 }

--- a/Shared/Entity/Enemy/Shaman.swift
+++ b/Shared/Entity/Enemy/Shaman.swift
@@ -31,6 +31,8 @@ class Shaman: Entity {
             component.projectileMaxDistance = 200
             component.projectileTexture = "Enemies/Shaman_Projectile"
             component.explosionTexture = "Enemies/Shaman_Explosion"
+            component.projectileScale = 0.5
+            component.explosionScale = 0.5
         }))
     }
 }

--- a/Shared/Entity/Projectile.swift
+++ b/Shared/Entity/Projectile.swift
@@ -8,7 +8,7 @@ import SpriteKit
 class Projectile: Entity {
     let projectileComponent: ProjectileComponent
 
-    init(speed: CGFloat, maxDistance: CGFloat, damage: Int, knockback: CGFloat, direction: CGPoint, ownerType: EntityType, projectileTexture: String = "Projectiles/5", explosionTexture: String = "Effects/4_1") {
+    init(speed: CGFloat, maxDistance: CGFloat, damage: Int, knockback: CGFloat, direction: CGPoint, ownerType: EntityType, projectileTexture: String = "Projectiles/5", explosionTexture: String = "Effects/4_1", projectileScale: CGFloat = 1.0, explosionScale: CGFloat = 1.0) {
         self.projectileComponent = ProjectileComponent(speed: speed, damage: damage, knockback: knockback, ownerType: ownerType, explosionTexture: explosionTexture)
         super.init()
         entityType = [.projectile]
@@ -22,8 +22,11 @@ class Projectile: Entity {
         addComponent(mover)
 
         projectileComponent.maxDistance = maxDistance
+        projectileComponent.explosionScale = explosionScale
         addComponent(projectileComponent)
-        addComponent(SpriteComponent(textureName: projectileTexture, autoRotateWithVelocity: true))
+        let spriteComponent = SpriteComponent(textureName: projectileTexture, autoRotateWithVelocity: true)
+        spriteComponent.sprite.setScale(projectileScale)
+        addComponent(spriteComponent)
         addComponent(TrailComponent(textureName: projectileTexture))
     }
 }


### PR DESCRIPTION
## Summary
- Added `projectileScale` and `explosionScale` properties to `ProjectileAttackComponent` with default values of 1.0
- Set both scale values to 0.5 for Shaman, Gnoll, and HarpoonFish enemies to make their projectiles and explosions smaller

## Changes Made
- **ProjectileAttackComponent**: Added `projectileScale` and `explosionScale` properties
- **Projectile class**: Updated constructor to accept scale parameters and apply projectile scaling to sprite
- **ProjectileComponent**: Added `explosionScale` property and applied it to explosion effects
- **Enemy entities**: Set scale values to 0.5 for Shaman, Gnoll, and HarpoonFish

## Test plan
- [x] Build project successfully
- [x] Verify projectiles and explosions are scaled correctly in gameplay
- [x] Confirm default scaling (1.0) works for other projectile users like turrets

🤖 Generated with [Claude Code](https://claude.ai/code)